### PR TITLE
Update RedmineCLI to v0.8.1

### DIFF
--- a/bucket/redmine.json
+++ b/bucket/redmine.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Command-line interface for Redmine - Efficiently manage Redmine tickets from your terminal",
     "homepage": "https://github.com/arstella-ltd/RedmineCLI",
     "license": "MIT",
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/arstella-ltd/RedmineCLI/releases/download/v0.8.0/redmine-cli-win-x64.zip",
-            "hash": "020cbf536974a96b68e7a39dbdda0dfedbf5e5ee0abf8923bd9c55ab14aa18a7"
+            "url": "https://github.com/arstella-ltd/RedmineCLI/releases/download/v0.8.1/redmine-cli-0.8.1-win-x64.zip",
+            "hash": "c6b932ba34beb914e9786323606f61c2437359e54610c82349d1eb3003602d19"
         }
     },
     "bin": "redmine.exe",


### PR DESCRIPTION
## Summary
Update RedmineCLI to the latest version 0.8.1

## Changes
- Updated version from 0.8.0 to 0.8.1
- Updated download URL to use the new filename format: `redmine-cli-0.8.1-win-x64.zip`
- Updated SHA256 hash: `c6b932ba34beb914e9786323606f61c2437359e54610c82349d1eb3003602d19`

## Release Notes
For detailed release notes, see: https://github.com/arstella-ltd/RedmineCLI/releases/tag/v0.8.1

## Test Plan
- [x] Scoop install works correctly with the new version
- [x] GitHub Actions validation passes