### PR TITLE
Add Qx (Query eXpress) CLI tool

### DIFF
--- a/bucket/qx.json
+++ b/bucket/qx.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.1.0",
+    "description": "OpenAI API-powered intelligent CLI tool with advanced web search capabilities",
+    "homepage": "https://github.com/arstella-ltd/Qx",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/arstella-ltd/Qx/releases/download/v0.1.0/qx-0.1.0-win-x64.zip",
+            "hash": "5d01392447113a2b137c174591a9ee78ed4741aeb4c568a56bb38869cbd3fa12",
+            "extract_dir": "qx-0.1.0-win-x64"
+        }
+    },
+    "bin": "qx.exe",
+    "checkver": {
+        "github": "https://github.com/arstella-ltd/Qx"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/arstella-ltd/Qx/releases/download/v$version/qx-$version-win-x64.zip",
+                "extract_dir": "qx-$version-win-x64"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/arstella-ltd/Qx/releases/download/v$version/qx-$version-checksums.txt",
+            "regex": "$sha256\\s+qx-$version-win-x64.zip"
+        }
+    },
+    "notes": [
+        "Qx requires an OpenAI API key to function.",
+        "Set the OPENAI_API_KEY environment variable with your API key:",
+        "",
+        "  [System.Environment]::SetEnvironmentVariable('OPENAI_API_KEY', 'your-api-key', 'User')",
+        "",
+        "For more information, visit: https://github.com/arstella-ltd/Qx"
+    ]
+}


### PR DESCRIPTION
## Summary
- Qx v0.1.0のScoopマニフェストを追加
- OpenAI APIを活用したインテリジェントCLIツール

## Changes
- `bucket/qx.json`: 新しいマニフェストファイルを追加
  - Windows 64-bit版バイナリのサポート
  - SHA256ハッシュによる検証
  - 自動アップデート設定
  - OpenAI APIキー設定に関する注意事項

## Test plan
- [ ] `scoop install qx` でインストール可能
- [ ] バイナリのハッシュが正しく検証される
- [ ] `qx --version` でバージョン情報が表示される
- [ ] OpenAI APIキーを設定後、基本的なクエリが動作する