### PR TITLE
Fix: Remove extract_dir from qx manifest

### DIFF
--- a/bucket/qx.json
+++ b/bucket/qx.json
@@ -6,8 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/arstella-ltd/Qx/releases/download/v0.1.0/qx-0.1.0-win-x64.zip",
-            "hash": "5d01392447113a2b137c174591a9ee78ed4741aeb4c568a56bb38869cbd3fa12",
-            "extract_dir": "qx-0.1.0-win-x64"
+            "hash": "5d01392447113a2b137c174591a9ee78ed4741aeb4c568a56bb38869cbd3fa12"
         }
     },
     "bin": "qx.exe",
@@ -17,8 +16,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/arstella-ltd/Qx/releases/download/v$version/qx-$version-win-x64.zip",
-                "extract_dir": "qx-$version-win-x64"
+                "url": "https://github.com/arstella-ltd/Qx/releases/download/v$version/qx-$version-win-x64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
## Summary
- qx.jsonマニフェストから`extract_dir`設定を削除
- インストールエラーを修正

## Problem
`scoop install qx`実行時に以下のエラーが発生:
```
Could not find 'qx-0.1.0-win-x64'! (error 16)
```

## Root Cause
ZIPファイルは`qx.exe`を直接ルートレベルに含んでおり、サブディレクトリが存在しないため、`extract_dir`の指定が不要でした。

## Solution
- `extract_dir: "qx-0.1.0-win-x64"`を削除
- `autoupdate`セクションからも同様に削除

## Test plan
- [x] ZIPファイル構造を確認済み（`qx.exe`が直接含まれている）
- [ ] `scoop install qx`でインストールが成功することを確認
- [ ] `qx --version`でバージョン情報が表示されることを確認