### PR TITLE
chore: v0.9.1に更新

### DIFF
--- a/bucket/redmine.json
+++ b/bucket/redmine.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.0",
+    "version": "0.9.1",
     "description": "Command-line interface for Redmine - Efficiently manage Redmine tickets from your terminal",
     "homepage": "https://github.com/arstella-ltd/RedmineCLI",
     "license": "MIT",
@@ -10,8 +10,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/arstella-ltd/RedmineCLI/releases/download/v0.9.0/redmine-cli-0.9.0-win-x64.zip",
-            "hash": "1092798bd2592c3126efd953346d3027f5b4d4eaac7b59deb6687dcc8bcd2ee1"
+            "url": "https://github.com/arstella-ltd/RedmineCLI/releases/download/v0.9.1/redmine-cli-0.9.1-win-x64.zip",
+            "hash": "d35b03f766fd45d40c5d28ef49631921cdfaca74a87e0e905b0499699d4d1d33"
         }
     },
     "bin": "redmine.exe",


### PR DESCRIPTION
RedmineCLI v0.9.1 のリリースに合わせてバージョンとハッシュを更新